### PR TITLE
`makeExtension` now correctly extracts the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ et dolore magna aliqua.
 
 Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
 ut aliquip ex ea commodo consequat.
----
+--
 Some images in the middle column:
 ![One](image-1.png)
 ![Two](image-2.png)
----
+--
 And some **more** text in the _third_ column. Duis aute irure dolor in
 reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 

--- a/mdx_grid.py
+++ b/mdx_grid.py
@@ -483,6 +483,6 @@ class GridExtension(markdown.Extension):
         md.postprocessors.add('grid', postprocessor, '_end')
 
 
-def makeExtension(configs=None):
+def makeExtension(**configs):
     """Markdown extension initializer."""
     return GridExtension(configs=configs)


### PR DESCRIPTION
This fixes:
- a config bug causing extension not to work in newer versions of python-markdown
- an example bug where columns were separated by `---` where it should be `--`
